### PR TITLE
Fix timestamp difference on Discord duration bar

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -351,15 +351,16 @@ namespace MusicBeePlugin
 
       _discordPresence.State = padString(_layoutHandler.Render(_settings.PresenceState, metaDataDict, _settings.Separator));
 
-      var t = DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1));
+      long t = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
       if (_settings.ShowTime && playerGetPlayState == PlayState.Playing)
       {
-        var totalRemainingDuration = _mbApiInterface.NowPlaying_GetDuration() - _mbApiInterface.Player_GetPosition();
+        int playerPosition = _mbApiInterface.Player_GetPosition();
+        int duration = _mbApiInterface.NowPlaying_GetDuration();
         _discordPresence.Timestamps = new Timestamps
         {
-          StartUnixMilliseconds = (ulong)(Math.Round(t.TotalSeconds) - Math.Round(_mbApiInterface.Player_GetPosition() / 1000.0)),
-          EndUnixMilliseconds = (ulong)(Math.Round(t.TotalSeconds) + Math.Round(totalRemainingDuration / 1000.0))
+          StartUnixMilliseconds = (ulong)(t - playerPosition),
+          EndUnixMilliseconds = (ulong)(t + duration - playerPosition)
         };
       }
 


### PR DESCRIPTION
This push request contains a fix for a slight discrepancy that was noticed between the time/duration that was actually shown on MusicBee, and the time/duration that was shown on the Discord profile.

I had noticed that the time shown on Discord was often 1 second longer than what MusicBee was saying it was (for example, 6:28 for a song that was actually 6:27), and looking into the source code I realised that this was probably because of some rounding that was happening losing some of the millisecond components. 

I've changed it to just use milliseconds throughout and to let Discord handle the calculations, and i've tested it with a bunch of tracks and haven't found any cases where the time is actually off (even by a second).